### PR TITLE
feat: setup CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,23 +10,20 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@2e3e4b15a884dc73a63f962bff250a855150a234
         with:
           python-version: '3.13'
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          cache: 'pip'
+          pip-install: -r requirements.txt
       
       - name: Build documentation
         run: mkdocs build
       
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4b09552702d0b65573696410d4707c765da2630b
         with:
           personal_token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           external_repository: pylonmc/pylonmc.github.io

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -10,17 +10,14 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@2e3e4b15a884dc73a63f962bff250a855150a234
         with:
           python-version: '3.13'
-      
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          cache: 'pip'
+          pip-install: -r requirements.txt
       
       - name: Check documentation build
         run: |


### PR DESCRIPTION
Closes #1

This PR sets up GitHub Actions for automatic deployment and pull request build testing. The deployment can also be triggered manually.

**Note: Please set up the secret `DOCS_DEPLOY_TOKEN` which is a PAT that has access to `pylonmc.github.io` repository.** The default `GITHUB_TOKEN` does not have access to external repository.